### PR TITLE
Tweak rest-client dependency.

### DIFF
--- a/dwolla-ruby.gemspec
+++ b/dwolla-ruby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     s.test_files    = `git ls-files -- test/*`.split("\n")
     s.require_paths = %w{lib}
 
-    s.add_dependency('rest-client', '~> 1.7.3')
+    s.add_dependency('rest-client', '~> 1.7', '>= 1.7.3')
     s.add_dependency('multi_json', '>= 1.0.4', '< 2')
     s.add_dependency('addressable', '>= 2')
 


### PR DESCRIPTION
Allow any 1.x of rest-client greater than or equal to 1.7.3

Currently as written, the dependency does not allow the most recent version of rest-client which is 1.8.0
