### PR TITLE
Change endpoint for offsite checkouts to match current API docs

### DIFF
--- a/lib/dwolla/offsite_gateway.rb
+++ b/lib/dwolla/offsite_gateway.rb
@@ -63,8 +63,6 @@ module Dwolla
 
         def self.get_checkout_url(destinationId)
             params = {
-                :key => Dwolla::api_key,
-                :secret => Dwolla::api_secret,
                 :allowFundingSources => @allow_funding_sources,
                 :additionalFundingSources => @additional_funding_sources,
                 :test => @test_mode,
@@ -84,10 +82,10 @@ module Dwolla
                 }
             }
 
-            resp = Dwolla.request(:post, request_url, params, {}, false, false, true)
+            resp = Dwolla.request(:post, request_url, params, {}, false)
 
             return "No data received." unless resp.is_a?(Hash)
-            raise APIError.new(resp['Message']) unless resp.has_key?('Result') and resp['Result'] == 'Success'
+            raise APIError.new('No CheckoutId returned') unless resp.has_key?('CheckoutId')
 
             return checkout_url + resp['CheckoutId']
         end
@@ -120,11 +118,7 @@ module Dwolla
         end
 
         def self.request_url
-            if Dwolla::sandbox
-                return 'https://uat.dwolla.com/payment/request'
-            else
-                return 'https://www.dwolla.com/payment/request'
-            end
+            '/offsitegateway/checkouts'
         end
 
         def self.checkout_url


### PR DESCRIPTION
I was getting HTML instead of JSON returned from calls to return offsite checkout URLs. The HTML I saw in my logs was asking for a Captcha to be solved. I thought this was due to the different API endpoint that's used by this code: `/payment/checkout`, instead of  the `/oauth/rest/offsitegateway/checkouts`, endpoint [described](https://docs.dwolla.com/?ruby#create-a-checkout) in the API.

But after changing the code to what's in this pull, I was still getting the same HTML returned. The next day, it started working. I then reverted to the original code, which also worked. So perhaps there has been some problem at the Dwolla end.

Even if both endpoints work, it would be good to merge this update so that this package matches the current API docs.