### PR TITLE
Match extract_authorization expectations

### DIFF
--- a/lib/dwolla/requests.rb
+++ b/lib/dwolla/requests.rb
@@ -1,6 +1,6 @@
 module Dwolla
     class Requests
-        def self.get(id=nil, filters={}, token=nil)
+        def self.get(id=nil, filters={}, token=true)
             url = requests_url
 
             if id.is_a?(Hash)
@@ -15,7 +15,7 @@ module Dwolla
             Dwolla.request(:get, url, filters, {}, token)
         end
 
-        def self.delete(id=nil, token=nil)
+        def self.delete(id=nil, token=true)
             raise MissingParameterError.new('No Request ID Provided.') if id.nil?
 
             url = requests_url + id.to_s + '/cancel'
@@ -23,7 +23,7 @@ module Dwolla
             Dwolla.request(:post, url, {}, {}, token)
         end
 
-        def self.create(params={}, token=nil)
+        def self.create(params={}, token=true)
             raise MissingParameterError.new('No Source ID Provided.') unless params[:sourceId]
             raise MissingParameterError.new('No Amount Provided.') unless params[:amount]
 
@@ -32,7 +32,7 @@ module Dwolla
             Dwolla.request(:post, url, params, {}, token)
         end
 
-        def self.fulfill(id=nil, params={}, token=nil)
+        def self.fulfill(id=nil, params={}, token=true)
             raise MissingParameterError.new('No Request ID Provided.') if id.nil?
             raise MissingParameterError.new('No PIN Provided.') unless params[:pin]
 


### PR DESCRIPTION
`dwolla.rb#extract_authorization` expects oauthToken (which comes from `token`) to be `false`, `true`, or an actual `Oauth Token`. Defaulting to `nil` causes the test `oauthToken.is_a?(TrueClass)` to be false which causes `nil` to be used as the actual token. 

This change maintains pre-3.0.0 functionality based on setting `Dwolla::token`