### PR TITLE
Stop passing a nil token by default

### DIFF
--- a/lib/dwolla/accounts.rb
+++ b/lib/dwolla/accounts.rb
@@ -1,6 +1,6 @@
 module Dwolla
     class Accounts
-        def self.get_auto_withdrawal_status(token=nil)
+        def self.get_auto_withdrawal_status(token=true)
           url = accounts_url + 'features/auto_withdrawl'
 
           Dwolla.request(:get, url, {}, {}, token)

--- a/lib/dwolla/balance.rb
+++ b/lib/dwolla/balance.rb
@@ -1,6 +1,6 @@
 module Dwolla
     class Balance
-        def self.get(token=nil)
+        def self.get(token=true)
             url = balance_url
 
             Dwolla.request(:get, url, {}, {}, token)

--- a/lib/dwolla/contacts.rb
+++ b/lib/dwolla/contacts.rb
@@ -1,6 +1,6 @@
 module Dwolla
     class Contacts
-        def self.get(filters={}, token=nil)
+        def self.get(filters={}, token=true)
             url = contacts_url
 
             Dwolla.request(:get, url, filters, {}, token)

--- a/lib/dwolla/funding_sources.rb
+++ b/lib/dwolla/funding_sources.rb
@@ -1,6 +1,6 @@
 module Dwolla
     class FundingSources
-        def self.get(id=nil, token=nil)
+        def self.get(id=nil, token=true)
             url = funding_sources_url
 
             url += id.to_s unless id.nil?
@@ -8,7 +8,7 @@ module Dwolla
             Dwolla.request(:get, url, {}, {}, token)
         end
 
-        def self.withdraw(id=nil, params={}, token=nil)
+        def self.withdraw(id=nil, params={}, token=true)
             raise MissingParameterError.new('No Funding Source ID Provided.') if id.nil?
             raise MissingParameterError.new('No PIN Provided.') unless params[:pin]
             raise MissingParameterError.new('No Amount Provided.') unless params[:amount]
@@ -19,7 +19,7 @@ module Dwolla
             Dwolla.request(:post, url, params, {}, token)
         end
 
-        def self.deposit(id=nil, params={}, token=nil)
+        def self.deposit(id=nil, params={}, token=true)
             raise MissingParameterError.new('No Funding Source ID Provided.') if id.nil?
             raise MissingParameterError.new('No PIN Provided.') unless params[:pin]
             raise MissingParameterError.new('No Amount Provided.') unless params[:amount]
@@ -30,7 +30,7 @@ module Dwolla
             Dwolla.request(:post, url, params, {}, token)
         end
 
-        def self.add(params={}, token=nil)
+        def self.add(params={}, token=true)
             raise MissingParameterError.new('No Account Number Provided.') unless params[:account_number]
             raise MissingParameterError.new('No Routing Number (ABA) Provided.') unless params[:routing_number]
             raise MissingParameterError.new('No Account Type Provided.') unless params[:account_type]
@@ -41,7 +41,7 @@ module Dwolla
             Dwolla.request(:post, url, params, {}, token)
         end
 
-        def self.verify(id=nil, params={}, token=nil)
+        def self.verify(id=nil, params={}, token=true)
             raise MissingParameterError.new('No Funding Source ID Provided.') if id.nil?
             raise MissingParameterError.new('No Deposit 1 Amount Provided.') unless params[:deposit1]
             raise MissingParameterError.new('No Deposit 2 Amount Provided.') unless params[:deposit2]

--- a/lib/dwolla/masspay.rb
+++ b/lib/dwolla/masspay.rb
@@ -1,11 +1,11 @@
 module Dwolla
   class MassPay
 
-    def self.get(token=nil)
+    def self.get(token=true)
       Dwolla.request(:get, masspay_url, {}, {}, token);
     end
 
-    def self.create(params={}, token=nil)
+    def self.create(params={}, token=true)
       raise MissingParameterError.new('No fundsSource ID Provided.') unless params[:fundsSource]
       raise MissingParameterError.new('No PIN Provided.') unless params[:pin]
       raise MissingParameterError.new('No Items Provided.') unless params[:items]
@@ -13,7 +13,7 @@ module Dwolla
       Dwolla.request(:post, masspay_url, params, {}, token)
     end
 
-    def self.getItems(id=nil, params={}, token=nil)
+    def self.getItems(id=nil, params={}, token=true)
       raise MissingParameterError.new('No MassPay Job ID Provided.') if id.nil?
       url = masspay_url
       url += id.to_s unless id.nil?
@@ -22,7 +22,7 @@ module Dwolla
       Dwolla.request(:get, url, params, {}, token)
     end
 
-    def self.getItem(jobId=nil, itemId=nil, token=nil)
+    def self.getItem(jobId=nil, itemId=nil, token=true)
       raise MissingParameterError.new('No MassPay Job ID Provided.') if jobId.nil?
       raise MissingParameterError.new('No Item ID Provided.') if itemId.nil?
 
@@ -34,7 +34,7 @@ module Dwolla
       Dwolla.request(:get, url, {}, {}, token)
     end
 
-    def self.getJob(id=nil, token=nil)
+    def self.getJob(id=nil, token=true)
       raise MissingParameterError.new('No MassPay Job ID Provided.') if id.nil?
 
       url = masspay_url

--- a/lib/dwolla/oauth.rb
+++ b/lib/dwolla/oauth.rb
@@ -64,7 +64,7 @@ module Dwolla
       return resp
     end
 
-    def self.catalog(token=nil)
+    def self.catalog(token=true)
       resp = Dwolla.request(:get, '/catalog', {}, {}, token, false, false)
 
       return "No data received." unless resp.is_a?(Hash)

--- a/lib/dwolla/transactions.rb
+++ b/lib/dwolla/transactions.rb
@@ -1,6 +1,6 @@
 module Dwolla
     class Transactions
-        def self.get(id=nil, filters={}, token=nil)
+        def self.get(id=nil, filters={}, token=true)
             url = transactions_url
 
             if id.is_a?(Hash)
@@ -13,13 +13,13 @@ module Dwolla
             Dwolla.request(:get, url, filters, {}, token)
         end
 
-        def self.stats(filters={}, token=nil)
+        def self.stats(filters={}, token=true)
             url = transactions_url + 'stats'
 
             Dwolla.request(:get, url, filters, {}, token)
         end
 
-        def self.create(params={}, token=nil)
+        def self.create(params={}, token=true)
             raise MissingParameterError.new('No Destination ID Provided.') unless params[:destinationId]
             raise MissingParameterError.new('No Amount Provided.') unless params[:amount]
 
@@ -28,7 +28,7 @@ module Dwolla
             Dwolla.request(:post, url, params, {}, token)
         end
 
-        def self.refund(params={}, token=nil)
+        def self.refund(params={}, token=true)
             raise MissingParameterError.new('No PIN Provided.') unless params[:pin]
             raise MissingParameterError.new('No Funding Source Provided.') unless params[:fundsSource]
             raise MissingParameterError.new('No Transaction ID Provided.') unless params[:transactionId]
@@ -39,7 +39,7 @@ module Dwolla
             Dwolla.request(:post, url, params, {}, token)
         end
 
-        def self.schedule(params={}, token=nil)
+        def self.schedule(params={}, token=true)
             raise MissingParameterError.new('No PIN Provided.') unless params[:pin]
             raise MissingParameterError.new('No Destination ID Provided.') unless params[:destinationId]
             raise MissingParameterError.new('No Amount Provided.') unless params[:amount]
@@ -51,13 +51,13 @@ module Dwolla
             Dwolla.request(:post, url, params, {}, token)
         end
 
-        def self.scheduled(filters={}, token=nil)
+        def self.scheduled(filters={}, token=true)
             url = transactions_url + 'scheduled'
 
             Dwolla.request(:get, url, filters, {}, token)
         end
 
-        def self.scheduled_by_id(id, token=nil)
+        def self.scheduled_by_id(id, token=true)
             raise MissingParameterError.new('No Scheduled Transaction ID Provided.') unless id
 
             url = transactions_url + 'scheduled/' 
@@ -66,7 +66,7 @@ module Dwolla
             Dwolla.request(:get, url, {}, {}, token)
         end
 
-        def self.edit_scheduled(id, params={}, token=nil)
+        def self.edit_scheduled(id, params={}, token=true)
             raise MissingParameterError.new('No PIN Provided.') unless params[:pin]
             raise MissingParameterError.new('No Scheduled Transaction ID Provided.') unless id
 
@@ -76,7 +76,7 @@ module Dwolla
             Dwolla.request(:put, url, params, {}, token)
         end
 
-        def self.delete_scheduled_by_id(id, params={}, token=nil)
+        def self.delete_scheduled_by_id(id, params={}, token=true)
             raise MissingParameterError.new('No PIN Provided.') unless params[:pin]
             raise MissingParameterError.new('No Scheduled Transaction ID Provided.') unless id
 
@@ -86,7 +86,7 @@ module Dwolla
             Dwolla.request(:delete, url, params, {}, token)
         end        
 
-        def self.delete_all_scheduled(params={}, token=nil)
+        def self.delete_all_scheduled(params={}, token=true)
             raise MissingParameterError.new('No PIN Provided.') unless params[:pin]
 
             url = transactions_url + 'scheduled' 

--- a/lib/dwolla/users.rb
+++ b/lib/dwolla/users.rb
@@ -21,13 +21,13 @@ module Dwolla
             self.get(nil, token)
         end
 
-        def self.nearby(params={}, token=true)
+        def self.nearby(params={})
           raise MissingParameterError.new('No Latitude Provided') unless params[:latitude]
           raise MissingParameterError.new('No Longitude Provided') unless params[:longitude]
 
           url = users_url + 'nearby'
 
-          Dwolla.request(:get, url, params, {}, token)
+          Dwolla.request(:get, url, params, {}, false)
         end
 
         private

--- a/lib/dwolla/users.rb
+++ b/lib/dwolla/users.rb
@@ -1,6 +1,6 @@
 module Dwolla
     class Users
-        def self.get(id=nil, token=nil)
+        def self.get(id=nil, token=true)
             url = users_url
 
             unless id.nil?
@@ -13,7 +13,7 @@ module Dwolla
             Dwolla.request(:get, url, {}, {}, @oauth)
         end
 
-        def self.me(token=nil)
+        def self.me(token=true)
             # I'm not using the 'alias_method' fn
             # because the .me method should not
             # honor any parameters (i.e. User IDs)
@@ -21,13 +21,13 @@ module Dwolla
             self.get(nil, token)
         end
 
-        def self.nearby(params={})
+        def self.nearby(params={}, token=true)
           raise MissingParameterError.new('No Latitude Provided') unless params[:latitude]
           raise MissingParameterError.new('No Longitude Provided') unless params[:longitude]
 
           url = users_url + 'nearby'
 
-          Dwolla.request(:get, url, params, {}, false)
+          Dwolla.request(:get, url, params, {}, token)
         end
 
         private

--- a/test/test_funding_sources.rb
+++ b/test/test_funding_sources.rb
@@ -7,6 +7,16 @@ class FundingSourcesTest < Test::Unit::TestCase
     Dwolla.stubs(:request).with(:get, '/fundingsources/123456', {}, {}, 'abc')
     Dwolla::FundingSources.get('123456', 'abc')
   end
+  
+  def test_get_without_specifying_token
+    Dwolla.stubs(:request).with(:get, '/fundingsources/123456', {}, {}, true)
+    Dwolla::FundingSources.get('123456')
+  end
+  
+  def test_get_all_without_specifying_token
+    Dwolla.stubs(:request).with(:get, '/fundingsources/', {}, {}, true)
+    Dwolla::FundingSources.get()
+  end  
 
   def test_withdraw
     Dwolla.stubs(:request).with(:post, '/fundingsources/123456/withdraw',

--- a/test/test_users.rb
+++ b/test/test_users.rb
@@ -9,7 +9,7 @@ class UsersTest < Test::Unit::TestCase
   end
 
   def test_get_id
-    Dwolla.stubs(:request).with(:get, '/users/812-111-1111', {}, {}, true)
+    Dwolla.stubs(:request).with(:get, '/users/812-111-1111', {}, {}, false)
     Dwolla::Users.get('812-111-1111')
   end
 

--- a/test/test_users.rb
+++ b/test/test_users.rb
@@ -25,7 +25,7 @@ class UsersTest < Test::Unit::TestCase
                                 {
                                     :latitude => 45,
                                     :longitude => 50
-                                }, {}, true)
+                                }, {}, false)
     Dwolla::Users.nearby({
                              :latitude => 45,
                              :longitude => 50

--- a/test/test_users.rb
+++ b/test/test_users.rb
@@ -9,7 +9,7 @@ class UsersTest < Test::Unit::TestCase
   end
 
   def test_get_id
-    Dwolla.stubs(:request).with(:get, '/users/812-111-1111', {}, {}, false)
+    Dwolla.stubs(:request).with(:get, '/users/812-111-1111', {}, {}, true)
     Dwolla::Users.get('812-111-1111')
   end
 
@@ -25,7 +25,7 @@ class UsersTest < Test::Unit::TestCase
                                 {
                                     :latitude => 45,
                                     :longitude => 50
-                                }, {}, false)
+                                }, {}, true)
     Dwolla::Users.nearby({
                              :latitude => 45,
                              :longitude => 50


### PR DESCRIPTION
When an actual Dwolla method is called without explicitly passing a token, the Dwolla method defaults to `nil` which is passed through to `extract_authorizations` and fails. This changes the default to `true`. 